### PR TITLE
Use gentyref 1.2.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 	<dependency>
 		<groupId>com.googlecode.gentyref</groupId>
 		<artifactId>gentyref</artifactId>
-		<version>1.1.0</version>
+		<version>1.2.0</version>
 	</dependency>
 	<dependency>
 		<groupId>asm</groupId>


### PR DESCRIPTION
Hi! I've verified that gentyref 1.2.0 works for us.

I will shortly create another pull request that changes pom.xml to use maven-shade-plugin, to create an uberjar that i used to test.
