### PR TITLE
gentyref is part of the API, and must not be relocated by maven-shade-plugin in the uberjar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,6 @@
               <shadedClassifierName>uberjar</shadedClassifierName>
               <relocations>
                 <relocation>
-                  <pattern>com.googlecode.gentyref</pattern>
-                  <shadedPattern>se.mockachino.dependencies.com.googlecode.gentyref</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>net.sf.cglib</pattern>
                   <shadedPattern>se.mockachino.dependencies.net.sf.cglib</shadedPattern>
                 </relocation>


### PR DESCRIPTION
Hi, i'm sorry, i made a mistake with the uberjar.

Gentyref is part of the API of mockachino and should not be relocated to se.mockachino.dependencies.com.googlecode.gentyref.
